### PR TITLE
prevent InputPopover form submit from submitting parent form

### DIFF
--- a/src/ui/InputPopover.js
+++ b/src/ui/InputPopover.js
@@ -66,6 +66,7 @@ export default class InputPopover extends Component<Props> {
 
   _onSubmit(event: Object) {
     event.preventDefault();
+    event.stopPropagation();
     this.props.onSubmit(this._inputRef.value);
   }
 


### PR DESCRIPTION
When wrapping `<RichTextEditor>` in a form, I noticed that submitting the form for `<InputPopover>` (like when adding a link) was also submitting the parent form. This prevents it from doing that.