### PR TITLE
use props instead of hard-coded placeholder

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -55,7 +55,8 @@ export default class RichTextEditor extends Component<Props> {
     let {props} = this;
     let editorState = props.value.getEditorState();
     let className = cx(props.className, styles.root);
-
+    let placeholder = props.placeholder ? props.placeholder : 'Tell a Story';
+    
     // If the user changes block type before entering any text, we can either
     // style the placeholder or hide it. Let's just hide it for now.
     let editorClassName = cx({
@@ -80,7 +81,7 @@ export default class RichTextEditor extends Component<Props> {
             handleKeyCommand={this._handleKeyCommand}
             onTab={this._onTab}
             onChange={this._onChange}
-            placeholder="Tell a story..."
+            placeholder={placeholder}
             ref="editor"
             spellCheck={true}
           />

--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -56,7 +56,6 @@ export default class RichTextEditor extends Component<Props> {
     let editorState = props.value.getEditorState();
     let className = cx(props.className, styles.root);
     let placeholder = props.placeholder ? props.placeholder : 'Tell a Story';
-    
     // If the user changes block type before entering any text, we can either
     // style the placeholder or hide it. Let's just hide it for now.
     let editorClassName = cx({


### PR DESCRIPTION
I had problems with using a placeholder in my app. First I've tried it by using the property "placeholder" but for unknown reasons the original "Tell a Story" didn't want to disappear. So I introduced a new property "placeholder". If set to null/undefined the original "Tell a Story" will be used instead.

I hope this solution is OK.