### PR TITLE
Default placeholder to empty string

### DIFF
--- a/src/EditorDemo.js
+++ b/src/EditorDemo.js
@@ -36,6 +36,7 @@ export default class EditorDemo extends Component<Props, State> {
           <RichTextEditor
             value={value}
             onChange={this._onChange}
+            placeholder="Tell a story"
           />
         </div>
         <div className="row">

--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -55,7 +55,7 @@ export default class RichTextEditor extends Component<Props> {
     let {props} = this;
     let editorState = props.value.getEditorState();
     let className = cx(props.className, styles.root);
-    let placeholder = props.placeholder ? props.placeholder : 'Tell a Story';
+    let placeholder = props.placeholder ? props.placeholder : '';
     // If the user changes block type before entering any text, we can either
     // style the placeholder or hide it. Let's just hide it for now.
     let editorClassName = cx({


### PR DESCRIPTION
This provides a basic default (the empty string) for the placeholder instead of a string of actual text, which could wind up appearing in a production app somewhere (and would then possibly need to be translated for i18n, etc.).

I've moved the default placeholder text ("Tell a story") into a prop passed to the `RichTextEditor` component.