### PR TITLE
modify image style

### DIFF
--- a/src/lib/EditorToolbar.js
+++ b/src/lib/EditorToolbar.js
@@ -3,7 +3,7 @@ import {hasCommandModifier} from 'draft-js/lib/KeyBindingUtil';
 
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
-import {EditorState, Entity, RichUtils} from 'draft-js';
+import {EditorState, Entity, RichUtils, Modifier} from 'draft-js';
 import {ENTITY_TYPE} from 'draft-js-utils';
 import {
   INLINE_STYLE_BUTTONS,
@@ -155,18 +155,11 @@ export default class EditorToolbar extends Component {
   }
 
   _renderImageButton(): React.Element {
-    const {editorState} = this.props;
-    let selection = editorState.getSelection();
-    let entity = this._getEntityAtCursor();
-    let hasSelection = !selection.isCollapsed();
-    let isCursorOnImage = (entity != null && entity.type === ENTITY_TYPE.IMAGE);
-    let shouldShowImageButton = hasSelection || isCursorOnImage;
     return (
       <ButtonGroup>
         <PopoverIconButton
           label="Image"
           iconName="image"
-          isDisabled={!shouldShowImageButton}
           showPopover={this.state.showImageInput}
           onTogglePopover={this._toggleShowImageInput}
           onSubmit={this._setImage}
@@ -252,11 +245,13 @@ export default class EditorToolbar extends Component {
 
   _setImage(src: string) {
     let {editorState} = this.props;
+    let contentState = editorState.getCurrentContent();
     let selection = editorState.getSelection();
     let entityKey = Entity.create(ENTITY_TYPE.IMAGE, 'IMMUTABLE', {src});
+    const updatedContent = Modifier.insertText(contentState, selection, ' ', null, entityKey);
     this.setState({showImageInput: false});
     this.props.onChange(
-      RichUtils.toggleLink(editorState, selection, entityKey)
+      EditorState.push(editorState, updatedContent)
     );
     this._focusEditor();
   }

--- a/src/ui/ImageSpan.css
+++ b/src/ui/ImageSpan.css
@@ -1,8 +1,6 @@
 .root {
-  color: transparent;
   background-repeat: no-repeat;
   display: inline-block;
-  text-align: right;
   cursor: pointer;
 }
 

--- a/src/ui/ImageSpan.js
+++ b/src/ui/ImageSpan.js
@@ -75,10 +75,14 @@ export default class ImageSpan extends Component {
     });
     const imageStyle = {
       //...resizingStyles,
+      verticalAlign: 'bottom',
       backgroundImage: `url("${src}")`,
       backgroundSize: `${width}px ${height}px`,
+      lineHeight: `${height}px`,
+      fontSize: `${height}`,
       width,
       height,
+      letterSpacing: width,
     };
 
     const imageSpan = (


### PR DESCRIPTION
Make content of `image` to single empty character but whole selected string ..

Image can insert into text directly use `Modifier.insertText` instead of `RichUtils.toggleLink`..

may it useful.
