### PR TITLE
User provided styles for toolbar and editor containers

### DIFF
--- a/src/EditorDemo.js
+++ b/src/EditorDemo.js
@@ -27,6 +27,7 @@ export default class EditorDemo extends Component {
 
   render(): React.Element {
     let {value, format} = this.state;
+
     return (
       <div className="editor-demo">
         <div className="row">
@@ -38,6 +39,8 @@ export default class EditorDemo extends Component {
             onChange={this._onChange}
             className="react-rte-demo"
             placeholder="Tell a story"
+            toolbarClassName="demo-toolbar"
+            editorClassName="demo-editor"
           />
         </div>
         <div className="row">

--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -38,6 +38,8 @@ type ChangeHandler = (value: EditorValue) => any;
 
 type Props = {
   className?: string;
+  toolbarClassName?: string;
+  editorClassName?: string;
   value: EditorValue;
   onChange?: ChangeHandler;
   placeholder?: string;
@@ -54,23 +56,25 @@ export default class RichTextEditor extends Component {
   }
 
   render(): React.Element {
-    let {value, className, placeholder, ...otherProps} = this.props;
+    let {value, className, toolbarClassName, editorClassName, placeholder, ...otherProps} = this.props;
     let editorState = value.getEditorState();
+
     // If the user changes block type before entering any text, we can either
     // style the placeholder or hide it. Let's just hide it for now.
-    let editorClassName = cx({
+    let combinedEditorClassName = cx({
       [styles.editor]: true,
       [styles.hidePlaceholder]: this._shouldHidePlaceholder(),
-    });
+    }, editorClassName);
     return (
-      <div className={cx(className, styles.root)}>
+      <div className={cx(styles.root, className)}>
         <EditorToolbar
+          className={toolbarClassName}
           keyEmitter={this._keyEmitter}
           editorState={editorState}
           onChange={this._onChange}
           focusEditor={this._focus}
         />
-        <div className={editorClassName}>
+        <div className={combinedEditorClassName}>
           <Editor
             {...otherProps}
             blockStyleFn={getBlockStyle}

--- a/src/lib/EditorToolbar.js
+++ b/src/lib/EditorToolbar.js
@@ -18,6 +18,7 @@ import IconButton from '../ui/IconButton';
 import getEntityAtCursor from './getEntityAtCursor';
 import clearEntityForRange from './clearEntityForRange';
 import autobind from 'class-autobind';
+import cx from 'classnames';
 
 // $FlowIssue - Flow doesn't understand CSS Modules
 import styles from './EditorToolbar.css';
@@ -27,6 +28,7 @@ import type {EventEmitter} from 'events';
 type ChangeHandler = (state: EditorState) => any;
 
 type Props = {
+  className?: string;
   editorState: EditorState;
   keyEmitter: EventEmitter;
   onChange: ChangeHandler;
@@ -60,8 +62,9 @@ export default class EditorToolbar extends Component {
   }
 
   render(): React.Element {
+    const {className} = this.props;
     return (
-      <div className={styles.root}>
+      <div className={cx(styles.root, className)}>
         {this._renderInlineStyleButtons()}
         {this._renderBlockTypeButtons()}
         {this._renderLinkButtons()}


### PR DESCRIPTION
Allow the appending of user provided classNames to the toolbar container and the editor container divs.