### PR TITLE
Allow to set customStyleMap on Editor

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -43,6 +43,7 @@ type Props = {
   value: EditorValue;
   onChange?: ChangeHandler;
   placeholder?: string;
+  customStyleMap?: {};
 };
 
 export default class RichTextEditor extends Component {
@@ -56,7 +57,7 @@ export default class RichTextEditor extends Component {
   }
 
   render(): React.Element {
-    let {value, className, toolbarClassName, editorClassName, placeholder, ...otherProps} = this.props;
+    let {value, className, toolbarClassName, editorClassName, placeholder, customStyleMap, ...otherProps} = this.props;
     let editorState = value.getEditorState();
 
     // If the user changes block type before entering any text, we can either
@@ -78,7 +79,7 @@ export default class RichTextEditor extends Component {
           <Editor
             {...otherProps}
             blockStyleFn={getBlockStyle}
-            customStyleMap={styleMap}
+            customStyleMap={Object.assign(styleMap, customStyleMap)}
             editorState={editorState}
             handleReturn={this._handleReturn}
             keyBindingFn={this._customKeyHandler}


### PR DESCRIPTION
This PR merges the internal `styleMap` const and the `customStyleMap` prop before setting it on `Editor`

In README it says:

> All the props you can pass to Draft.js Editor can be passed to RichTextEditor (with the exception of editorState which will be generated internally based on the value prop).

Which is not totally right. I guess there's more props which is overridden by `rte`, `customStyleMap` is just one of them.

Thanks for an awesome _draftjs_ wrapper.