### PR TITLE
pre-fill link input with the current href value

### DIFF
--- a/src/lib/EditorToolbar.js
+++ b/src/lib/EditorToolbar.js
@@ -132,16 +132,17 @@ export default class EditorToolbar extends Component {
     let entity = this._getEntityAtCursor();
     let hasSelection = !selection.isCollapsed();
     let isCursorOnLink = (entity != null && entity.type === ENTITY_TYPE.LINK);
-    let shouldShowLinkButton = hasSelection || isCursorOnLink;
+    let data = entity && entity.data;
     return (
       <ButtonGroup>
         <PopoverIconButton
           label="Link"
           iconName="link"
-          isDisabled={!shouldShowLinkButton}
+          isDisabled={!hasSelection}
           showPopover={this.state.showLinkInput}
           onTogglePopover={this._toggleShowLinkInput}
           onSubmit={this._setLink}
+          data={data}
         />
         <IconButton
           label="Remove Link"

--- a/src/ui/InputPopover.js
+++ b/src/ui/InputPopover.js
@@ -11,6 +11,7 @@ import styles from './InputPopover.css';
 
 type Props = {
   className?: string;
+  data: ?Object;
   onCancel: () => any;
   onSubmit: (value: string) => any;
 };
@@ -40,6 +41,7 @@ export default class InputPopover extends Component {
   render(): React.Element {
     let {props} = this;
     let className = cx(props.className, styles.root);
+    let defaultValue = props.data && props.data.url;
     return (
       <form className={className} onSubmit={this._onSubmit}>
         <div className={styles.inner}>
@@ -48,6 +50,7 @@ export default class InputPopover extends Component {
             type="text"
             placeholder="https://example.com/"
             className={styles.input}
+            defaultValue={defaultValue}
           />
           <ButtonGroup className={styles.buttonGroup}>
             <IconButton

--- a/src/ui/PopoverIconButton.js
+++ b/src/ui/PopoverIconButton.js
@@ -8,6 +8,7 @@ import autobind from 'class-autobind';
 type Props = {
   iconName: string;
   showPopover: boolean,
+  data: ?Object,
   onTogglePopover: Function,
   onSubmit: Function;
 };
@@ -37,6 +38,7 @@ export default class PopoverIconButton extends Component {
       <InputPopover
         onSubmit={this._onSubmit}
         onCancel={this._hidePopover}
+        data={this.props.data}
       />
     );
   }


### PR DESCRIPTION
#15  I fixed this and slightly changed the way the link button acts.
Currently, Popover IconButton of Link is enabled when both hasSelection and isCursorOnLink,
but I think that it should be enabled only when hasSelection because you cannot change href value when isCursorOnLink. I think users should be notified that link can be set only when they select block, not when they put cursor on link.

By the way, I'm not sure my codes fit your coding style.