### PR TITLE
Exclude node_modules from babel loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,11 @@
 var path = require('path');
 
 var loaders = [
-  {test: /\.js$/, loader: 'babel'},
+  {
+    test: /\.js$/,
+    loader: 'babel',
+    exclude: /node_modules/
+  },
   {
     test: /\.css$/,
     exclude: /\.global\.css$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ var loaders = [
   {
     test: /\.js$/,
     loader: 'babel',
-    exclude: /node_modules/
+    exclude: /node_modules/,
   },
   {
     test: /\.css$/,


### PR DESCRIPTION
I have a project that is performing server-side rendering, and it fails when I include `react-rte` in the project. I've tracked it down to how a transitive dependency of `react-rte`, `ua-parser-js`, is being processed via Babel.

The fix is to exclude `node_modules` from being processed with `babel-loader` via Webpack.

Background:

According to [some (old) Babel docs](https://github.com/babel/babel.github.io/blob/862b43db93e48762671267034a50c30c00e433e2/docs/faq.md#why-is-this-being-remapped-to-undefined), top-level `this` references will be translated to undefined, which causes what would effectively be a ref to `global` to be trashed, thus breaking server-side rendering.

The specific code that is impacted in `ua-parser-js` can be found in `dist/react-rte.js` by searching for `jQuery` - but the root cause is the logic that works out whether to pass `window` or `this` into the module's overall IIFE.