### PR TITLE
Prevent passing unknown properties to buttons

### DIFF
--- a/src/lib/StyleButton.js
+++ b/src/lib/StyleButton.js
@@ -17,7 +17,7 @@ export default class StyleButton extends Component {
   }
 
   render(): React.Element {
-    let {style, ...otherProps} = this.props;
+    let {style, onToggle, ...otherProps} = this.props; // eslint-disable-line no-unused-vars
     let iconName = style.toLowerCase();
     // `focusOnClick` will prevent the editor from losing focus when a control
     // button is clicked.

--- a/src/ui/Button.js
+++ b/src/ui/Button.js
@@ -31,10 +31,10 @@ export default class Button extends Component {
 
   render(): React.Element {
     let {props} = this;
-    let {className, isDisabled, ...otherProps} = props;
+    let {className, isDisabled, focusOnClick, formSubmit, ...otherProps} = props;
     className = cx(className, styles.root);
-    let onMouseDown = (props.focusOnClick === false) ? this._onMouseDownPreventDefault : props.onMouseDown;
-    let type = props.formSubmit ? 'submit' : 'button';
+    let onMouseDown = (focusOnClick === false) ? this._onMouseDownPreventDefault : props.onMouseDown;
+    let type = formSubmit ? 'submit' : 'button';
     return (
       <button type={type} {...otherProps} onMouseDown={onMouseDown} className={className} disabled={isDisabled}>
         {props.children}

--- a/src/ui/IconButton.js
+++ b/src/ui/IconButton.js
@@ -24,10 +24,10 @@ export default class IconButton extends Component {
 
   render(): React.Element {
     let {props} = this;
-    let {className, iconName, label, children, ...otherProps} = props;
+    let {className, iconName, label, children, isActive, ...otherProps} = props;
     className = cx(className, {
       [styles.root]: true,
-      [styles.isActive]: props.isActive,
+      [styles.isActive]: isActive,
     });
     return (
       <ButtonWrap>

--- a/src/ui/PopoverIconButton.js
+++ b/src/ui/PopoverIconButton.js
@@ -21,9 +21,9 @@ export default class PopoverIconButton extends Component {
   }
 
   render(): React.Element {
-    let {props} = this;
+    let {onTogglePopover, showPopover, ...props} = this.props; // eslint-disable-line no-unused-vars
     return (
-      <IconButton {...props} onClick={this.props.onTogglePopover}>
+      <IconButton {...props} onClick={onTogglePopover}>
         {this._renderPopover()}
       </IconButton>
     );


### PR DESCRIPTION
This PR addresses #20

Note that I disable eslint warning on unused variables on two lines. I believe that this is a good tradeoff for clean and simple code.
