### PR TITLE
Eliminate dead code from output bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 /*eslint-env node */
 var path = require('path');
+var webpack = require('webpack');
 
 var loaders = [
   {
@@ -30,6 +31,16 @@ module.exports = [{
     'react-dom': 'react-dom',
   },
   module: {loaders: loaders},
+  plugins: [
+    new webpack.optimize.UglifyJsPlugin({
+      beautify: true,
+      comments: true,
+      mangle: false,
+      compress: {
+        dead_code: true,
+      },
+    }),
+  ],
 }, {
   entry: './src/demo.js',
   output: {


### PR DESCRIPTION
This should make react-rte work in browserify.  The issue before was the code for hot module reloading of CSS, but that code had already been put inside an `if(false){}` block as part of the build process.  Adding the uglify plugin with these options causes it to **only** do dead code elimination, removing the calls to `require` css modules that don't exist.