### PR TITLE
fix: support SSR

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -287,7 +287,7 @@ function createEmptyValue(): EditorValue {
   return EditorValue.createEmpty(decorator);
 }
 
-function createValueFromString(markup: string, format: string, options: ?Options): EditorValue {
+function createValueFromString(markup: string, format: string, options?: Options): EditorValue {
   return EditorValue.createFromString(markup, format, decorator, options);
 }
 

--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -20,6 +20,7 @@ import styles from './RichTextEditor.css';
 
 import type {ContentBlock} from 'draft-js';
 import type {ToolbarConfig} from './lib/EditorToolbarConfig';
+import type {Options} from './lib/EditorValue';
 
 const MAX_LIST_DEPTH = 2;
 
@@ -286,8 +287,8 @@ function createEmptyValue(): EditorValue {
   return EditorValue.createEmpty(decorator);
 }
 
-function createValueFromString(markup: string, format: string): EditorValue {
-  return EditorValue.createFromString(markup, format, decorator);
+function createValueFromString(markup: string, format: string, options: ?Options): EditorValue {
+  return EditorValue.createFromString(markup, format, decorator, options);
 }
 
 // $FlowIssue - This should probably not be done this way.

--- a/src/lib/EditorValue.js
+++ b/src/lib/EditorValue.js
@@ -6,6 +6,8 @@ import {stateToMarkdown} from 'draft-js-export-markdown';
 import {stateFromMarkdown} from 'draft-js-import-markdown';
 
 import type {DraftDecoratorType as Decorator} from 'draft-js/lib/DraftDecoratorType';
+import type {Options} from 'draft-js-import-html';
+export type {Options};
 
 type StringMap = {[key: string]: string};
 
@@ -36,10 +38,10 @@ export default class EditorValue {
     return (this._cache[format] = toString(this.getEditorState(), format));
   }
 
-  setContentFromString(markup: string, format: string): EditorValue {
+  setContentFromString(markup: string, format: string, options: ?Options): EditorValue {
     let editorState = EditorState.push(
       this._editorState,
-      fromString(markup, format),
+      fromString(markup, format, options),
       'secondary-paste'
     );
     return new EditorValue(editorState, {[format]: markup});
@@ -54,8 +56,8 @@ export default class EditorValue {
     return new EditorValue(editorState);
   }
 
-  static createFromString(markup: string, format: string, decorator: ?Decorator): EditorValue {
-    let contentState = fromString(markup, format);
+  static createFromString(markup: string, format: string, decorator: ?Decorator, options: ?Options): EditorValue {
+    let contentState = fromString(markup, format, options);
     let editorState = EditorState.createWithContent(contentState, decorator);
     return new EditorValue(editorState, {[format]: markup});
   }
@@ -76,10 +78,10 @@ function toString(editorState: EditorState, format: string): string {
   }
 }
 
-function fromString(markup: string, format: string): ContentState {
+function fromString(markup: string, format: string, options: ?Options): ContentState {
   switch (format) {
     case 'html': {
-      return stateFromHTML(markup);
+      return stateFromHTML(markup, options);
     }
     case 'markdown': {
       return stateFromMarkdown(markup);

--- a/src/lib/EditorValue.js
+++ b/src/lib/EditorValue.js
@@ -38,7 +38,7 @@ export default class EditorValue {
     return (this._cache[format] = toString(this.getEditorState(), format));
   }
 
-  setContentFromString(markup: string, format: string, options: ?Options): EditorValue {
+  setContentFromString(markup: string, format: string, options?: Options): EditorValue {
     let editorState = EditorState.push(
       this._editorState,
       fromString(markup, format, options),
@@ -56,7 +56,7 @@ export default class EditorValue {
     return new EditorValue(editorState);
   }
 
-  static createFromString(markup: string, format: string, decorator: ?Decorator, options: ?Options): EditorValue {
+  static createFromString(markup: string, format: string, decorator: ?Decorator, options?: Options): EditorValue {
     let contentState = fromString(markup, format, options);
     let editorState = EditorState.createWithContent(contentState, decorator);
     return new EditorValue(editorState, {[format]: markup});
@@ -78,7 +78,7 @@ function toString(editorState: EditorState, format: string): string {
   }
 }
 
-function fromString(markup: string, format: string, options: ?Options): ContentState {
+function fromString(markup: string, format: string, options?: Options): ContentState {
   switch (format) {
     case 'html': {
       return stateFromHTML(markup, options);


### PR DESCRIPTION
`stateFromHTML` supports using a custom parser, but this module did not take advantage of that. Appropriate methods on `RichTextEditor` and `EditorValue` now accept an options object of the same type as `draft-js-import-html`. 

When testing this with our own project, we have used [parse5](https://github.com/inikulin/parse5) to parse HTML on the server (or the default parser on the client) for rendering HTML. We do not attempt to render the editor on the server, and just `setState` or `forceUpdate()` in `componentDidMount` to rerender with an editor instead of HTML on the client. This works for us, since you can't actually use the editor as such server side, natch. 