### PR TITLE
support `stateToHTML` options to allow custom block renderers

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -20,7 +20,7 @@ import styles from './RichTextEditor.css';
 
 import type {ContentBlock} from 'draft-js';
 import type {ToolbarConfig} from './lib/EditorToolbarConfig';
-import type {Options} from './lib/EditorValue';
+import type {ImportOptions} from './lib/EditorValue';
 
 const MAX_LIST_DEPTH = 2;
 
@@ -287,7 +287,7 @@ function createEmptyValue(): EditorValue {
   return EditorValue.createEmpty(decorator);
 }
 
-function createValueFromString(markup: string, format: string, options?: Options): EditorValue {
+function createValueFromString(markup: string, format: string, options?: ImportOptions): EditorValue {
   return EditorValue.createFromString(markup, format, decorator, options);
 }
 

--- a/src/lib/EditorValue.js
+++ b/src/lib/EditorValue.js
@@ -6,8 +6,9 @@ import {stateToMarkdown} from 'draft-js-export-markdown';
 import {stateFromMarkdown} from 'draft-js-import-markdown';
 
 import type {DraftDecoratorType as Decorator} from 'draft-js/lib/DraftDecoratorType';
-import type {Options} from 'draft-js-import-html';
-export type {Options};
+import type {Options as ImportOptions} from 'draft-js-import-html';
+import type {Options as ExportOptions} from 'draft-js-export-html';
+export type {ImportOptions, ExportOptions};
 
 type StringMap = {[key: string]: string};
 
@@ -30,15 +31,15 @@ export default class EditorValue {
       new EditorValue(editorState);
   }
 
-  toString(format: string): string {
+  toString(format: string, options?: ExportOptions): string {
     let fromCache = this._cache[format];
     if (fromCache != null) {
       return fromCache;
     }
-    return (this._cache[format] = toString(this.getEditorState(), format));
+    return (this._cache[format] = toString(this.getEditorState(), format, options));
   }
 
-  setContentFromString(markup: string, format: string, options?: Options): EditorValue {
+  setContentFromString(markup: string, format: string, options?: ImportOptions): EditorValue {
     let editorState = EditorState.push(
       this._editorState,
       fromString(markup, format, options),
@@ -56,18 +57,18 @@ export default class EditorValue {
     return new EditorValue(editorState);
   }
 
-  static createFromString(markup: string, format: string, decorator: ?Decorator, options?: Options): EditorValue {
+  static createFromString(markup: string, format: string, decorator: ?Decorator, options?: ImportOptions): EditorValue {
     let contentState = fromString(markup, format, options);
     let editorState = EditorState.createWithContent(contentState, decorator);
     return new EditorValue(editorState, {[format]: markup});
   }
 }
 
-function toString(editorState: EditorState, format: string): string {
+function toString(editorState: EditorState, format: string, options?: ExportOptions): string {
   let contentState = editorState.getCurrentContent();
   switch (format) {
     case 'html': {
-      return stateToHTML(contentState);
+      return stateToHTML(contentState, options);
     }
     case 'markdown': {
       return stateToMarkdown(contentState);
@@ -78,7 +79,7 @@ function toString(editorState: EditorState, format: string): string {
   }
 }
 
-function fromString(markup: string, format: string, options?: Options): ContentState {
+function fromString(markup: string, format: string, options?: ImportOptions): ContentState {
   switch (format) {
     case 'html': {
       return stateFromHTML(markup, options);


### PR DESCRIPTION
#102 added support for `stateFromHTML` options. This PR adds support for `stateToHTML` options. This allows you to add custom block renderers and inline-styles https://github.com/sstur/draft-js-export-html#options