### PR TITLE
Added support for custom blockStyleFn

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -48,6 +48,7 @@ type Props = {
   readOnly?: boolean;
   disabled?: boolean; // Alias of readOnly
   toolbarConfig?: ToolbarConfig;
+  blockStyleFn?: Function;
 };
 
 export default class RichTextEditor extends Component {
@@ -71,6 +72,7 @@ export default class RichTextEditor extends Component {
       readOnly,
       disabled,
       toolbarConfig,
+      blockStyleFn,
       ...otherProps // eslint-disable-line comma-dangle
     } = this.props;
     let editorState = value.getEditorState();
@@ -104,7 +106,7 @@ export default class RichTextEditor extends Component {
         <div className={combinedEditorClassName}>
           <Editor
             {...otherProps}
-            blockStyleFn={getBlockStyle}
+            blockStyleFn={getBlockStyle(blockStyleFn)}
             customStyleMap={customStyleMap}
             editorState={editorState}
             handleReturn={this._handleReturn}
@@ -267,7 +269,13 @@ export default class RichTextEditor extends Component {
   }
 }
 
-function getBlockStyle(block: ContentBlock): string {
+const getBlockStyle = (blockStyleFn?: Function): Function => (block: ContentBlock): string => {
+  if (blockStyleFn) {
+    const result = blockStyleFn(block);
+    if (result) {
+      return result;
+    }
+  }
   let result = styles.block;
   switch (block.getType()) {
     case 'unstyled':
@@ -279,7 +287,7 @@ function getBlockStyle(block: ContentBlock): string {
     default:
       return result;
   }
-}
+};
 
 const decorator = new CompositeDecorator([LinkDecorator]);
 

--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -10,6 +10,7 @@ import isSoftNewlineEvent from 'draft-js/lib/isSoftNewlineEvent';
 import EditorToolbar from './lib/EditorToolbar';
 import EditorValue from './lib/EditorValue';
 import LinkDecorator from './lib/LinkDecorator';
+import composite from './lib/composite';
 import cx from 'classnames';
 import autobind from 'class-autobind';
 import EventEmitter from 'events';
@@ -48,7 +49,7 @@ type Props = {
   readOnly?: boolean;
   disabled?: boolean; // Alias of readOnly
   toolbarConfig?: ToolbarConfig;
-  blockStyleFn?: Function;
+  blockStyleFn?: (block: ContentBlock) => ?string;
 };
 
 export default class RichTextEditor extends Component {
@@ -106,7 +107,7 @@ export default class RichTextEditor extends Component {
         <div className={combinedEditorClassName}>
           <Editor
             {...otherProps}
-            blockStyleFn={getBlockStyle(blockStyleFn)}
+            blockStyleFn={composite(defaultBlockStyleFn, blockStyleFn)}
             customStyleMap={customStyleMap}
             editorState={editorState}
             handleReturn={this._handleReturn}
@@ -269,13 +270,7 @@ export default class RichTextEditor extends Component {
   }
 }
 
-const getBlockStyle = (blockStyleFn?: Function): Function => (block: ContentBlock): string => {
-  if (blockStyleFn) {
-    const result = blockStyleFn(block);
-    if (result) {
-      return result;
-    }
-  }
+function defaultBlockStyleFn(block: ContentBlock): string {
   let result = styles.block;
   switch (block.getType()) {
     case 'unstyled':
@@ -287,7 +282,7 @@ const getBlockStyle = (blockStyleFn?: Function): Function => (block: ContentBloc
     default:
       return result;
   }
-};
+}
 
 const decorator = new CompositeDecorator([LinkDecorator]);
 

--- a/src/lib/__tests__/composite-test.js
+++ b/src/lib/__tests__/composite-test.js
@@ -1,0 +1,18 @@
+// @flow
+const {describe, it} = global;
+
+import composite from '../composite';
+import expect from 'expect';
+
+describe('composite', () => {
+  it('should return the composite of two functions', () => {
+    let addOne = (x) => x + 1;
+    let addTwo = (x) => x + 2;
+    expect(
+      composite(addOne, addTwo)(5)
+    ).toBe(7);
+    expect(
+      composite(addOne, undefined)(5)
+    ).toBe(6);
+  });
+});

--- a/src/lib/composite.js
+++ b/src/lib/composite.js
@@ -1,0 +1,18 @@
+// @flow
+
+function composite<T, U>(
+  defaultFunc: (input: T) => U,
+  customFunc?: (input: T) => ?U,
+): (input: T) => U {
+  return (input: T) => {
+    if (customFunc) {
+      let result = customFunc(input);
+      if (result != null) {
+        return result;
+      }
+    }
+    return defaultFunc(input);
+  };
+}
+
+export default composite;


### PR DESCRIPTION
https://github.com/sstur/react-rte/pull/111#issuecomment-255060028

The README states:

> All the props you can pass to Draft.js Editor can be passed to RichTextEditor (with the exception of editorState which will be generated internally based on the value prop).

This is currently not the case for blockStyleFn prop, it gets overridden by react-rte