### PR TITLE
Add autoFocus prop to support automatically focusing editor on mounting

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -50,6 +50,7 @@ type Props = {
   disabled?: boolean; // Alias of readOnly
   toolbarConfig?: ToolbarConfig;
   blockStyleFn?: (block: ContentBlock) => ?string;
+  autoFocus?: boolean;
 };
 
 export default class RichTextEditor extends Component {
@@ -60,6 +61,16 @@ export default class RichTextEditor extends Component {
     super(...arguments);
     this._keyEmitter = new EventEmitter();
     autobind(this);
+  }
+
+  componentDidMount() {
+    const {autoFocus} = this.props;
+
+    if (!autoFocus) {
+      return;
+    }
+
+    this._focus();
   }
 
   render() {


### PR DESCRIPTION
Hi there,

We need support in our project to have the Editor autofocus once it's mounted, so I've gone ahead and made the changes. Let me know if you have any issues with this approach.

ESLint is passing but I'm getting a bunch of Flow errors about `Duplicate module provider`, unsure if I'm doing something wrong.

Cheers,
Taylor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sstur/react-rte/117)
<!-- Reviewable:end -->
