### PR TITLE
Support draft 'raw' document import/export

### DIFF
--- a/src/lib/EditorValue.js
+++ b/src/lib/EditorValue.js
@@ -74,7 +74,7 @@ function toString(editorState: EditorState, format: string, options?: ExportOpti
       return stateToMarkdown(contentState);
     }
     case 'raw': {
-      return convertToRaw(contentState);
+      return JSON.stringify(convertToRaw(contentState));
     }
     default: {
       throw new Error('Format not supported: ' + format);
@@ -91,7 +91,7 @@ function fromString(markup: string, format: string, options?: ImportOptions): Co
       return stateFromMarkdown(markup);
     }
     case 'raw': {
-      return convertFromRaw(markup);
+      return convertFromRaw(JSON.parse(markup));
     }
     default: {
       throw new Error('Format not supported: ' + format);

--- a/src/lib/EditorValue.js
+++ b/src/lib/EditorValue.js
@@ -1,5 +1,5 @@
 /* @flow */
-import {ContentState, EditorState} from 'draft-js';
+import {ContentState, EditorState, convertToRaw, convertFromRaw} from 'draft-js';
 import {stateToHTML} from 'draft-js-export-html';
 import {stateFromHTML} from 'draft-js-import-html';
 import {stateToMarkdown} from 'draft-js-export-markdown';
@@ -73,6 +73,9 @@ function toString(editorState: EditorState, format: string, options?: ExportOpti
     case 'markdown': {
       return stateToMarkdown(contentState);
     }
+    case 'raw': {
+      return convertToRaw(contentState);
+    }
     default: {
       throw new Error('Format not supported: ' + format);
     }
@@ -86,6 +89,9 @@ function fromString(markup: string, format: string, options?: ImportOptions): Co
     }
     case 'markdown': {
       return stateFromMarkdown(markup);
+    }
+    case 'raw': {
+      return convertFromRaw(markup);
     }
     default: {
       throw new Error('Format not supported: ' + format);


### PR DESCRIPTION
This adds a new type `'raw'` to the `toString` and `fromString` methods which simply uses draft's `convertToRaw` and `convertFromRaw` functions. 

When I tried doing this in my own project:
```js
convertToRaw(value.getEditorState().getCurrentContent())
```
I ran into a peculiar issue where draft couldn't serialize documents with links. The issue appears to be with using two instances of `draft-js` (`react-rte`'s and my own for `convertToRaw`). It seems to be a problem with the way entities are stored outside of the `ContentState`, possibly in the `draft-js` instance itself (!?) which means that `convertToRaw` relies on some internal draft state, and so having two instances of draft is problematic. I considered making `react-rte` expose its draft instance, but I think allowing the import/export of the "raw" document may be desirable for many users.

I wonder if this should be `toRaw` and `fromRaw` instead? Any thoughts?