### PR TITLE
Added optional props to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,11 @@ In this editor we use a pure, deterministic function to convert document state t
 
 ### Other Props
   All the props you can pass to Draft.js `Editor` can be passed to `RichTextEditor` (with the exception of `editorState` which will be generated internally based on the `value` prop).
-  
-  * `autoFocus`: setting this to true will automatically focus input into the editor when the component is mounted
+
+  * `autoFocus`: Setting this to true will automatically focus input into the editor when the component is mounted
+  * `placeholder`: A string to use as placeholder text for the `RichTextEditor`.
+  * `readOnly`: A boolean that determines if the `RichTextEditor` should render static html.
+  * `disabled`: An alias for `readOnly`.
 
 ### EditorValue Class
 In Draft.js `EditorState` contains not only the document contents but the entire state of the editor including cursor position and selection. This is helpful for many reasons including undo/redo. To make things easier for you, we have wrapped the state of the editor in an `EditorValue` instance with helpful methods to convert to/from a HTML or Markdown. An instance of this class should be passed to `RichTextEditor` in the `value` prop.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ In this editor we use a pure, deterministic function to convert document state t
   * `autoFocus`: Setting this to true will automatically focus input into the editor when the component is mounted
   * `placeholder`: A string to use as placeholder text for the `RichTextEditor`.
   * `readOnly`: A boolean that determines if the `RichTextEditor` should render static html.
-  * `disabled`: An alias for `readOnly`.
 
 ### EditorValue Class
 In Draft.js `EditorState` contains not only the document contents but the entire state of the editor including cursor position and selection. This is helpful for many reasons including undo/redo. To make things easier for you, we have wrapped the state of the editor in an `EditorValue` instance with helpful methods to convert to/from a HTML or Markdown. An instance of this class should be passed to `RichTextEditor` in the `value` prop.


### PR DESCRIPTION
I recognize that the quote below addresses this and that these features are managed by Draft.js but it's not obvious at first glance and requires digging to realize these are available. 

> All the props you can pass to Draft.js `Editor` can be passed to `RichTextEditor` (with the exception of `editorState` which will be generated internally based on the `value` prop).