### PR TITLE
[Inline Style] Add new props 'rootStyle', 'editorStyle', 'toolbarStyle' 

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -51,6 +51,9 @@ type Props = {
   toolbarConfig?: ToolbarConfig;
   blockStyleFn?: (block: ContentBlock) => ?string;
   autoFocus?: boolean;
+  rootStyle?: Object;
+  editorStyle?: Object;
+  toolbarStyle?: Object;
 };
 
 export default class RichTextEditor extends Component {
@@ -85,6 +88,9 @@ export default class RichTextEditor extends Component {
       disabled,
       toolbarConfig,
       blockStyleFn,
+      rootStyle,
+      toolbarStyle,
+      editorStyle,
       ...otherProps // eslint-disable-line comma-dangle
     } = this.props;
     let editorState = value.getEditorState();
@@ -103,6 +109,7 @@ export default class RichTextEditor extends Component {
     if (!readOnly) {
       editorToolbar = (
         <EditorToolbar
+          rootStyle={toolbarStyle}
           className={toolbarClassName}
           keyEmitter={this._keyEmitter}
           editorState={editorState}
@@ -113,9 +120,9 @@ export default class RichTextEditor extends Component {
       );
     }
     return (
-      <div className={cx(styles.root, className)}>
+      <div className={cx(styles.root, className)} style={rootStyle}>
         {editorToolbar}
-        <div className={combinedEditorClassName}>
+        <div className={combinedEditorClassName} style={editorStyle}>
           <Editor
             {...otherProps}
             blockStyleFn={composite(defaultBlockStyleFn, blockStyleFn)}

--- a/src/lib/EditorToolbar.js
+++ b/src/lib/EditorToolbar.js
@@ -30,6 +30,7 @@ type Props = {
   onChange: ChangeHandler;
   focusEditor: Function;
   toolbarConfig: ToolbarConfig;
+  rootStyle?: Object;
 };
 
 type State = {
@@ -59,7 +60,7 @@ export default class EditorToolbar extends Component {
   }
 
   render() {
-    let {className, toolbarConfig} = this.props;
+    let {className, toolbarConfig, rootStyle} = this.props;
     if (toolbarConfig == null) {
       toolbarConfig = DefaultToolbarConfig;
     }
@@ -84,7 +85,7 @@ export default class EditorToolbar extends Component {
       }
     });
     return (
-      <div className={cx(styles.root, className)}>
+      <div className={cx(styles.root, className)} style={rootStyle}>
         {buttonsGroups}
       </div>
     );


### PR DESCRIPTION

This will allow to apply inline styles to root container, toolbar container and editor container.

Issue fixes: https://github.com/sstur/react-rte/issues/82

Ex:

```
<RichTextEditor
       value={RichTextEditor.createValueFromString(content, 'html')}
       rootStyle={{border: 'none', fontFamily: 'roboto'}}
       editorStyle={{padding: 22 }}
       toolbarStyle={{background: '#f5f5f5'}}
/>
```