### PR TITLE
Allow passing custom keyBindingFn prop

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -51,6 +51,7 @@ type Props = {
   toolbarConfig?: ToolbarConfig;
   blockStyleFn?: (block: ContentBlock) => ?string;
   autoFocus?: boolean;
+  keyBindingFn: (event: Object) => ?string;
 };
 
 export default class RichTextEditor extends Component {
@@ -85,6 +86,7 @@ export default class RichTextEditor extends Component {
       disabled,
       toolbarConfig,
       blockStyleFn,
+      keyBindingFn,
       ...otherProps // eslint-disable-line comma-dangle
     } = this.props;
     let editorState = value.getEditorState();
@@ -122,7 +124,7 @@ export default class RichTextEditor extends Component {
             customStyleMap={customStyleMap}
             editorState={editorState}
             handleReturn={this._handleReturn}
-            keyBindingFn={this._customKeyHandler}
+            keyBindingFn={keyBindingFn || this._customKeyHandler}
             handleKeyCommand={this._handleKeyCommand}
             onTab={this._onTab}
             onChange={this._onChange}


### PR DESCRIPTION
Using react-rte in a project, I need to be able to remove key bindings totally, since they are already managed by my app.

So this allows passing a custom keyBindingFn.

Maybe it would be better to pass an editorProps object to allow completely control the props of the Editor component.