### PR TITLE
Allow `extraProps` to be passed in with toolbarConfig

### DIFF
--- a/src/lib/EditorToolbar.js
+++ b/src/lib/EditorToolbar.js
@@ -101,6 +101,7 @@ export default class EditorToolbar extends Component {
     return (
       <ButtonGroup key={name}>
         <Dropdown
+          {...toolbarConfig.extraProps}
           choices={choices}
           selectedKey={blockType}
           onChange={this._selectBlockType}
@@ -113,6 +114,7 @@ export default class EditorToolbar extends Component {
     let blockType = this._getCurrentBlockType();
     let buttons = (toolbarConfig.BLOCK_TYPE_BUTTONS || []).map((type, index) => (
       <StyleButton
+        {...toolbarConfig.extraProps}
         key={String(index)}
         isActive={type.style === blockType}
         label={type.label}
@@ -131,6 +133,7 @@ export default class EditorToolbar extends Component {
     let currentStyle = editorState.getCurrentInlineStyle();
     let buttons = (toolbarConfig.INLINE_STYLE_BUTTONS || []).map((type, index) => (
       <StyleButton
+        {...toolbarConfig.extraProps}
         key={String(index)}
         isActive={currentStyle.has(type.style)}
         label={type.label}
@@ -144,7 +147,7 @@ export default class EditorToolbar extends Component {
     );
   }
 
-  _renderLinkButtons(name: string) {
+  _renderLinkButtons(name: string, toolbarConfig: ToolbarConfig) {
     let {editorState} = this.props;
     let selection = editorState.getSelection();
     let entity = this._getEntityAtCursor();
@@ -162,6 +165,7 @@ export default class EditorToolbar extends Component {
           onSubmit={this._setLink}
         />
         <IconButton
+          {...toolbarConfig.extraProps}
           label="Remove Link"
           iconName="remove-link"
           isDisabled={!isCursorOnLink}
@@ -172,13 +176,14 @@ export default class EditorToolbar extends Component {
     );
   }
 
-  _renderUndoRedo(name: string) {
+  _renderUndoRedo(name: string, toolbarConfig: ToolbarConfig) {
     let {editorState} = this.props;
     let canUndo = editorState.getUndoStack().size !== 0;
     let canRedo = editorState.getRedoStack().size !== 0;
     return (
       <ButtonGroup key={name}>
         <IconButton
+          {...toolbarConfig.extraProps}
           label="Undo"
           iconName="undo"
           isDisabled={!canUndo}
@@ -186,6 +191,7 @@ export default class EditorToolbar extends Component {
           focusOnClick={false}
         />
         <IconButton
+          {...toolbarConfig.extraProps}
           label="Redo"
           iconName="redo"
           isDisabled={!canRedo}

--- a/src/lib/EditorToolbarConfig.js
+++ b/src/lib/EditorToolbarConfig.js
@@ -12,6 +12,7 @@ export type GroupName = 'INLINE_STYLE_BUTTONS' | 'BLOCK_TYPE_BUTTONS' | 'LINK_BU
 
 export type ToolbarConfig = {
   display: Array<GroupName>;
+  extraProps?: Object;
   INLINE_STYLE_BUTTONS: StyleConfigList;
   BLOCK_TYPE_DROPDOWN: StyleConfigList;
   BLOCK_TYPE_BUTTONS: StyleConfigList;


### PR DESCRIPTION
The reason I need this is so that I can add `tabIndex="-1"` to all toolbar buttons, so that I can cleanly tab directly into the editor window, but it could be used to pass any additional attributes down to the `button`s.

Fixes #149