### PR TITLE
Fix webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 /*eslint-env node */
 var path = require('path');
+var webpack = require('webpack');
 
 var loaders = [
   {
@@ -19,13 +20,30 @@ var loaders = [
 ];
 
 module.exports = [{
-  entry: {
-    demo: './src/demo.js',
-  },
+  entry: './src/RichTextEditor.js',
   output: {
-    path: path.join(__dirname, 'assets/dist'),
-    publicPath: '/',
-    filename: '[name].js',
+    path: path.join(__dirname, 'dist'),
+    filename: 'react-rte.js',
+    libraryTarget: 'commonjs2',
+  },
+  externals: {
+    react: 'react',
+    'react-dom': 'react-dom',
+  },
+  module: {loaders: loaders},
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify('production'),
+      },
+    }),
+    new webpack.optimize.UglifyJsPlugin(),
+  ],
+}, {
+  entry: './src/demo.js',
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: 'demo.js',
   },
   module: {loaders: loaders},
 }];


### PR DESCRIPTION
As noted in #134, you cannot build this project from a fresh clone because the `webpack.config.js` file is missing several necessary config options. Also, as noted in #190, this distribution file is very large.

This PR adds back most of the config options that were removed in [this](https://github.com/sstur/react-rte/commit/237a48618f8788c93c4bbe5cdbca3aff225c5450) commit. I did remove the various options passed to `UglifyJsPlugin`, as removing those substantially decreased the bundle size (924kb -> 340kb).