### PR TITLE
Allow options to be passed into the markdown parser, so options like

### DIFF
--- a/src/lib/EditorValue.js
+++ b/src/lib/EditorValue.js
@@ -88,7 +88,7 @@ function fromString(markup: string, format: string, options?: ImportOptions): Co
       return stateFromHTML(markup, options);
     }
     case 'markdown': {
-      return stateFromMarkdown(markup);
+      return stateFromMarkdown(markup, options);
     }
     case 'raw': {
       return convertFromRaw(JSON.parse(markup));


### PR DESCRIPTION
{ breaks: true } can be passed in.