### PR TITLE
Fix rendering of customControls

### DIFF
--- a/src/lib/EditorToolbar.js
+++ b/src/lib/EditorToolbar.js
@@ -106,7 +106,7 @@ export default class EditorToolbar extends Component {
     if (customControls == null) {
       return;
     }
-    customControls.map((f) => {
+    return customControls.map((f) => {
       switch (typeof f) {
         case 'function': {
           return f(


### PR DESCRIPTION
Not 100% sure of the intended functionality of this method, but with this fix, it returns the value from `customControls.map(...)` to the `render()` method when its called.