### PR TITLE
SimpleRichTextEditor, fix `_updateStateFromProps`

### DIFF
--- a/src/SimpleRichTextEditor.js
+++ b/src/SimpleRichTextEditor.js
@@ -39,7 +39,7 @@ export default class SimpleRichTextEditor extends Component {
   _updateStateFromProps(newProps: Props) {
     let {value, format} = newProps;
     if (this._currentValue != null) {
-      let [currentValue, currentFormat] = this._currentValue;
+      let [currentFormat, currentValue] = this._currentValue;
       if (format === currentFormat && value === currentValue) {
         return;
       }


### PR DESCRIPTION
While following the code, I noticed that `this._currentValue` is not unpacked correctly in `_updateStateFromProps`.

`_currentValue` contains `[format, value]` but was unpacked as `[value, format]`.