### PR TITLE
Optimize bundle size.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,5 +6,12 @@
     ["babel-preset-es2015", { "modules": false }],
     "babel-preset-react",
     "babel-preset-stage-2"
-  ]
+  ],
+  "env": {
+    "test": {
+      "plugins": [
+        "transform-es2015-modules-commonjs"
+      ]
+    }
+  }
 }

--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,7 @@
     "transform-runtime"
   ],
   "presets": [
-    "babel-preset-es2015",
+    ["babel-preset-es2015", { "modules": false }],
     "babel-preset-react",
     "babel-preset-stage-2"
   ]

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepublish": "npm run build",
     "start": "webpack-dev-server --content-base assets/",
     "test": "npm run lint && npm run typecheck && npm run test-src",
-    "test-src": "mocha \"src/**/__tests__/*.js\""
+    "test-src": "BABEL_ENV=test mocha \"src/**/__tests__/*.js\""
   },
   "dependencies": {
     "babel-runtime": "^6.23.0",
@@ -39,6 +39,7 @@
     "babel-core": "^6.18.2",
     "babel-eslint": "^7.1.0",
     "babel-loader": "^7.1.1",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.11.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "build": "npm run build-lib && npm run build-dist",
-    "build-dist": "rimraf dist && webpack",
+    "build-dist": "rimraf dist && webpack -p",
     "build-lib": "rimraf lib && babel src --ignore \"_*\" --out-dir lib --copy-files",
     "lint": "eslint --max-warnings 0 .",
     "typecheck": "flow",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,15 +52,8 @@ module.exports = [{
         NODE_ENV: JSON.stringify('production'),
       },
     }),
-    new webpack.optimize.UglifyJsPlugin({
-      beautify: true,
-      comments: true,
-      mangle: false,
-      compress: {
-        dead_code: true,
-        warnings: false,
-      },
-    }),
+    new webpack.optimize.UglifyJsPlugin(),
+    new webpack.optimize.ModuleConcatenationPlugin(),
   ],
 }, {
   entry: './src/demo.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -617,7 +617,7 @@ babel-plugin-transform-es2015-modules-amd@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
+babel-plugin-transform-es2015-modules-commonjs@^6.24.1, babel-plugin-transform-es2015-modules-commonjs@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz#0d8394029b7dc6abe1a97ef181e00758dd2e5d8a"
   dependencies:


### PR DESCRIPTION
Change UglifyJS plugin options to remove comments, don't transpile es6
imports with babel to allow webpack to do tree shaking.
Configure scope hoisting.

fix #264 