### PR TITLE
Allow editing links

### DIFF
--- a/src/ui/InputPopover.js
+++ b/src/ui/InputPopover.js
@@ -10,6 +10,7 @@ import styles from './InputPopover.css';
 
 type Props = {
   className?: string;
+  defaultValue?: string;
   onCancel: () => any;
   onSubmit: (value: string) => any;
 };
@@ -44,6 +45,7 @@ export default class InputPopover extends Component {
         <div className={styles.inner}>
           <input
             ref={this._setInputRef}
+            defaultValue={props.defaultValue}
             type="text"
             placeholder="https://example.com/"
             className={styles.input}

--- a/src/ui/PopoverIconButton.js
+++ b/src/ui/PopoverIconButton.js
@@ -8,6 +8,7 @@ import autobind from 'class-autobind';
 type Props = {
   iconName: string;
   showPopover: boolean,
+  defaultValue?: string,
   onTogglePopover: Function,
   onSubmit: Function;
 };
@@ -35,6 +36,7 @@ export default class PopoverIconButton extends Component {
     }
     return (
       <InputPopover
+        defaultValue={this.props.defaultValue}
         onSubmit={this._onSubmit}
         onCancel={this._hidePopover}
       />


### PR DESCRIPTION
Currently, the "Create Link" button gets enabled when the cursor is over a link; but no value is prefilled and nothing actually happens when the button is used.

This PR changes this functionality to act as the user probably expects:
 - The link's URL is prefilled into the text input
 - The link's URL is updated when the submit button/enter is pressed

A small note: I originally tried updating the link with `ContentState.replaceEntityData` but that actually breaks undo functionality; it turns out entity data isn't handled immutably yet (https://github.com/facebook/draft-js/issues/1047). So instead we just always create a brand new link entity.

I see some previous attempts at this and discussion: https://github.com/sstur/react-rte/pull/59 and https://github.com/sstur/react-rte/issues/15. I think this implementation follows how the other formatting options work:
 - We only show the link's value and edit when no text is selected
 - If text is selected, pressing the link button acts exactly the same as it currently does: applying a new formatting to this selected text, overriding whatever link formatting may already exist on the selected text.

**Before** (Recorded on https://react-rte.org/demo)
![react-rte-link-button-does-nothing mkv](https://user-images.githubusercontent.com/1004194/37376004-6ad05c82-26df-11e8-9297-8edc6be65113.gif)

**After** (Recorded locally by building the demo... which apparently has some more buttons now)
![react-rte-edit-links-with-button mkv](https://user-images.githubusercontent.com/1004194/37378664-736053d0-26ed-11e8-95da-db72edfd053a.gif)

