### PR TITLE
rename unsafe react lifecycle methods

### DIFF
--- a/src/SimpleRichTextEditor.js
+++ b/src/SimpleRichTextEditor.js
@@ -33,7 +33,8 @@ export default class SimpleRichTextEditor extends Component {
     this._updateStateFromProps(this.props);
   }
 
-  componentWillReceiveProps(newProps: Props) {
+  // eslint-disable-next-line
+  UNSAFE_componentWillReceiveProps(newProps: Props) {
     this._updateStateFromProps(newProps);
   }
 

--- a/src/SimpleRichTextEditor.js
+++ b/src/SimpleRichTextEditor.js
@@ -28,7 +28,8 @@ export default class SimpleRichTextEditor extends Component {
     };
   }
 
-  componentWillMount() {
+  // eslint-disable-next-line
+  UNSAFE_componentWillMount() {
     this._updateStateFromProps(this.props);
   }
 

--- a/src/lib/EditorToolbar.js
+++ b/src/lib/EditorToolbar.js
@@ -56,7 +56,8 @@ export default class EditorToolbar extends Component {
     };
   }
 
-  componentWillMount() {
+  // eslint-disable-next-line
+  UNSAFE_componentWillMount() {
     // Technically, we should also attach/detach event listeners when the
     // `keyEmitter` prop changes.
     this.props.keyEmitter.on('keypress', this._onKeypress);


### PR DESCRIPTION
Unsafe react lifecycle methods are being renamed in React 17.0 to have the prefix UNSAFE_. As of React 16.9, there's a warning displayed in the console. More information here: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html