### PR TITLE
Fix warning "React does not recognize the checkOptions prop"

### DIFF
--- a/src/ui/PopoverIconButton.js
+++ b/src/ui/PopoverIconButton.js
@@ -25,7 +25,7 @@ export default class PopoverIconButton extends Component {
   }
 
   render() {
-    let {onTogglePopover, showPopover, ...props} = this.props; // eslint-disable-line no-unused-vars
+    let {onTogglePopover, showPopover, checkOptions, ...props} = this.props; // eslint-disable-line no-unused-vars
     return (
       <IconButton {...props} onClick={onTogglePopover}>
         {this._renderPopover()}


### PR DESCRIPTION
This fixes an "Error: unrecognized prop `checkOptions`.  The problem was simply that the component was passing it's new `checkOptions` prop along to the base HTML component, when it shouldn't have.

This fixes #374.