### PR TITLE
Allow hiding the toolbar externally

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -55,6 +55,7 @@ type Props = {
   handleReturn?: (event: Object) => boolean;
   customControls?: Array<CustomControl>;
   readOnly?: boolean;
+  toolbarHidden?: boolean;
   disabled?: boolean; // Alias of readOnly
   toolbarConfig?: ToolbarConfig;
   toolbarOnBottom?: boolean;
@@ -97,6 +98,7 @@ export default class RichTextEditor extends Component {
       placeholder,
       customStyleMap,
       readOnly,
+      toolbarHidden,
       disabled,
       toolbarConfig,
       toolbarOnBottom,
@@ -121,7 +123,7 @@ export default class RichTextEditor extends Component {
       readOnly = disabled;
     }
     let editorToolbar;
-    if (!readOnly) {
+    if (!readOnly && toolbarHidden) {
       editorToolbar = (
         <EditorToolbar
           rootStyle={toolbarStyle}

--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -123,7 +123,8 @@ export default class RichTextEditor extends Component {
       readOnly = disabled;
     }
     let editorToolbar;
-    if (!readOnly && toolbarHidden) {
+
+    if (!readOnly && !toolbarHidden) {
       editorToolbar = (
         <EditorToolbar
           rootStyle={toolbarStyle}


### PR DESCRIPTION
This lets you show/hide the toolbar from an external UI element. Useful, for instance, if you're editing a rich field, but usually don't care about formatting.

I would have preferred the positive `toolbarVisible` case instead, but I don't want to break existing implementations.