### PR TITLE
Fix Link and Image popover button not working in React 17

### DIFF
--- a/src/ui/InputPopover.js
+++ b/src/ui/InputPopover.js
@@ -48,7 +48,7 @@ export default class InputPopover extends Component {
   }
 
   componentDidMount() {
-    document.addEventListener('click', this._onDocumentClick);
+    document.addEventListener('click', this._onDocumentClick, true);
     document.addEventListener('keydown', this._onDocumentKeydown);
     if (this._inputRef) {
       this._inputRef.focus();
@@ -56,7 +56,7 @@ export default class InputPopover extends Component {
   }
 
   componentWillUnmount() {
-    document.removeEventListener('click', this._onDocumentClick);
+    document.removeEventListener('click', this._onDocumentClick, true);
     document.removeEventListener('keydown', this._onDocumentKeydown);
   }
 


### PR DESCRIPTION
React 17 has made [changes to event delegation](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation),
so it'll also call `_onDocumentClick` when trying to toggle popover (it make popover toggle **twice**: off -> on -> off)
![image](https://user-images.githubusercontent.com/18245813/107081823-dca7df80-6825-11eb-9982-cdbaac73b204.png)
