### PR TITLE
Add react 17.x to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "immutable": "^3.8.1"
   },
   "peerDependencies": {
-    "react": "0.14.x || 15.x.x || 16.x.x",
-    "react-dom": "0.14.x || 15.x.x || 16.x.x"
+    "react": "0.14.x || 15.x.x || 16.x.x || 17.x.x",
+    "react-dom": "0.14.x || 15.x.x || 16.x.x || 17.x.x"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",


### PR DESCRIPTION
#415 Notes that the compatibility for React 17.x.x has been added in 0.16.4, but as this hasn't been reflected in package.json, `npm install react-rte` still fails in a project using react 17.x.x.

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: campaign-of-kings@undefined
npm ERR! Found: react@17.0.2
npm ERR! node_modules/react
npm ERR!   react@"17.0.2" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"0.14.x || 15.x.x || 16.x.x" from react-rte@0.16.4
npm ERR! node_modules/react-rte
npm ERR!   react-rte@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

This adds `17.x.x` to the supported peerDependencies for `react` and `react-dom`.

Fixes #419 