### PR TITLE
Updated peerDependencies - React 18.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "immutable": "^3.8.1"
   },
   "peerDependencies": {
-    "react": "0.14.x || 15.x.x || 16.x.x || 17.x.x",
-    "react-dom": "0.14.x || 15.x.x || 16.x.x || 17.x.x"
+    "react": "0.14.x || 15.x.x || 16.x.x || 17.x.x || 18.x.x",
+    "react-dom": "0.14.x || 15.x.x || 16.x.x || 17.x.x || 18.x.x"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",


### PR DESCRIPTION
There was dependency error in React 18.x.x. No updated peerDependencies.